### PR TITLE
Added library file for platformio

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,18 @@
+{
+    "name": "Automaton",
+    "keywords": "state, machine",
+    "description": "A multi tasking table driven finite state machine framework for Arduino",
+    "authors":
+    {
+        "name": "Tinkerspy",
+        "email": "tinkerspy@myown.mailcan.com",
+        "url": "https://github.com/tinkerspy"
+    },
+    "repository":
+    {
+        "type": "git",
+        "url": "https://github.com/tinkerspy/Automaton"
+    },
+    "frameworks": "arduino",
+    "platforms": "atmelavr"
+}


### PR DESCRIPTION
We need this library file to enable Platformio (http://docs.platformio.org) users to use this library easily.

Library configuration file guideline
http://docs.platformio.org/en/latest/librarymanager/creating.html#register