### PR TITLE
Add blink-pattern functionality to Atm_led

### DIFF
--- a/examples/patternblink/patternblink.ino
+++ b/examples/patternblink/patternblink.ino
@@ -1,0 +1,32 @@
+#include <Arduino.h>
+#include <Automaton.h>
+#include <Atm_led.hpp>
+
+Atm_led led;
+byte bpattern[] = { 1,1,1,0,2,2,2,0,1,1,1,0,0 };
+
+Atm_led led2;
+byte bpattern2[] = { 1,1,0 };
+
+
+void setup() {
+	Serial.begin(9600);
+
+  	led2
+  	.blink(100,100)
+  	.begin(5, false, bpattern2, sizeof(bpattern2))
+	.onFinish(led,led.EVT_BLINK) 
+	;
+
+	led
+	.blink(100,100)
+	.begin(4, false, bpattern, sizeof(bpattern))
+	//.trace(Serial)
+	.onFinish(led2,led.EVT_BLINK) 
+   	.trigger( led.EVT_BLINK)
+   	;
+}
+
+void loop() {
+    automaton.run();
+}

--- a/src/Atm_led.cpp
+++ b/src/Atm_led.cpp
@@ -3,20 +3,25 @@
 Atm_led& Atm_led::begin( int attached_pin, bool activeLow, byte* blinkPattern, int blinkPatternSize ) {
   // clang-format off
   static const state_t state_table[] PROGMEM = {
-    /*               ON_ENTER    ON_LOOP    ON_EXIT  EVT_ON_TIMER  EVT_OFF_TIMER  EVT_COUNTER  EVT_ON  EVT_OFF  EVT_BLINK  EVT_TOGGLE  EVT_TOGGLE_BLINK  ELSE */
-    /* IDLE      */  ENT_INIT, ATM_SLEEP,        -1,           -1,            -1,          -1,     ON,      -1,     START,         ON,            START,    -1, // LED off
-    /* ON        */    ENT_ON, ATM_SLEEP,        -1,           -1,            -1,          -1,     -1,     OFF,     START,        OFF,              OFF,    -1, // LED on
-    /* START     */    ENT_ON,        -1,        -1,    BLINK_OFF,            -1,          -1,     ON,     OFF,        -1,        OFF,              OFF,    -1, // Start blinking
-    /* BLINK_OFF */   ENT_OFF,        -1,        -1,           -1,          LOOP,          -1,     ON,     OFF,        -1,        OFF,              OFF,    -1,
-    /* LOOP      */        -1,        -1,        -1,           -1,            -1,        DONE,     ON,     OFF,        -1,        OFF,              OFF, START,    
-    /* DONE      */        -1,        -1, EXT_CHAIN,           -1,           OFF,          -1,     ON,     OFF,     START,        OFF,              OFF,    -1, // Wait after last blink
-    /* OFF       */   ENT_OFF,        -1,        -1,           -1,            -1,          -1,     ON,     OFF,     START,         -1,               -1,  IDLE, // All off -> IDLE
-  };
+    /*               ON_ENTER    ON_LOOP    ON_EXIT  EVT_ON_TIMER  EVT_OFF_TIMER EVT_WT_TIMER EVT_COUNTER  EVT_ON  EVT_OFF  EVT_BLINK  EVT_TOGGLE  EVT_TOGGLE_BLINK   ELSE */
+    /* IDLE      */  ENT_INIT, ATM_SLEEP,        -1,           -1,            -1,          -1,         -1,  WT_ON,      -1,  WT_START,         ON,         WT_START,    -1, // LED off
+    /* ON        */    ENT_ON, ATM_SLEEP,        -1,           -1,            -1,          -1,         -1,     -1,     OFF,  WT_START,        OFF,              OFF,    -1, // LED on
+    /* START     */    ENT_ON,        -1,        -1,    BLINK_OFF,            -1,          -1,         -1,  WT_ON,     OFF,        -1,        OFF,              OFF,    -1, // Start blinking
+    /* BLINK_OFF */   ENT_OFF,        -1,        -1,           -1,          LOOP,          -1,         -1,  WT_ON,     OFF,        -1,        OFF,              OFF,    -1,
+    /* LOOP      */        -1,        -1,        -1,           -1,            -1,          -1,       DONE,  WT_ON,     OFF,        -1,        OFF,              OFF, START,    
+    /* DONE      */        -1,        -1, EXT_CHAIN,           -1,           OFF,          -1,         -1,  WT_ON,     OFF,  WT_START,        OFF,              OFF,    -1, // Wait after last blink
+    /* OFF       */   ENT_OFF,        -1,        -1,           -1,            -1,          -1,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,  IDLE, // All off -> IDLE
+    /* WT_ON     */        -1,        -1,        -1,           -1,            -1,          ON,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,    -1, // LEAD for ON
+    /* WT_START  */        -1,        -1,        -1,           -1,            -1,       START,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,    -1, // LEAD for BLINK
+  }; 
   // clang-format on
   Machine::begin( state_table, ELSE );
   pin = attached_pin;
   this->activeLow = activeLow;
   level = 255;
+  toLow = 0;
+  toHigh = 255;
+  wrap = false;
   pinMode( pin, OUTPUT );
   digitalWrite( pin, activeLow ? HIGH : LOW );
   pattern = blinkPattern;
@@ -44,6 +49,8 @@ int Atm_led::event( int id ) {
       return on_timer.expired( this );
     case EVT_OFF_TIMER:
       return off_timer.expired( this );
+    case EVT_WT_TIMER:
+      return lead_timer.expired( this );
     case EVT_COUNTER:
       return counter.expired();
   }
@@ -56,13 +63,15 @@ void Atm_led::action( int id ) {
       counter.set( repeat_count );
       return;
     case ENT_ON:
-      if ( activeLow ) {
-        digitalWrite( pin, LOW );
-      } else {
-        if ( level == 255 ) {
-          digitalWrite( pin, HIGH );
+      if ( on_timer.value > 0 ) { // Never turn if on_timer is zero (duty cycle 0 must be dark)
+        if ( activeLow ) {
+          digitalWrite( pin, LOW );
         } else {
-          analogWrite( pin, level );
+          if ( level == toHigh ) {
+            digitalWrite( pin, HIGH );
+          } else {
+            analogWrite( pin, mapLevel( level ) );
+          }
         }
       }
       return;
@@ -71,10 +80,10 @@ void Atm_led::action( int id ) {
       if ( !activeLow ) {
         digitalWrite( pin, LOW );
       } else {
-        if ( level == 255 ) {
+        if ( level == toHigh ) {
           digitalWrite( pin, HIGH );
         } else {
-          analogWrite( pin, level );
+          analogWrite( pin, mapLevel( level ) );
         }
       }
       if( state() == OFF ) {
@@ -91,6 +100,14 @@ void Atm_led::action( int id ) {
       reset();
       onfinish.push( 0 );
       return;
+  }
+}
+
+int Atm_led::mapLevel( int level ) {
+  if ( levelMapSize ) {
+    return levelMap[level];
+  } else {
+    return map( level, toLow, toHigh, 0, 255 );
   }
 }
 
@@ -143,6 +160,26 @@ Atm_led& Atm_led::blink( uint32_t duration ) {
   return *this;
 }
 
+Atm_led& Atm_led::blink( void ) {
+  trigger( EVT_BLINK );
+  return *this;
+}
+
+Atm_led& Atm_led::range( int toLow, int toHigh, bool wrap /* = false */ ) {
+  this->toLow = toLow; 
+  this->toHigh = toHigh; 
+  this->wrap = wrap;
+  level = toHigh;
+  return *this;
+}
+
+Atm_led& Atm_led::levels( unsigned char* map, int mapsize, bool wrap /* = false */ ) {
+  this->levelMap = map;
+  levelMapSize = mapsize;
+  range( 0, mapsize - 1, wrap );
+  return *this;
+}
+
 Atm_led& Atm_led::pause( uint32_t duration ) {  // Time in which led is fully off
   offDuration = duration;
   off_timer.set( duration ? duration : 1 );     // Make sure off_timer is never 0 (work around)
@@ -159,23 +196,51 @@ Atm_led& Atm_led::fade( int fade ) {
   return *this;
 }  // Dummy for method compatibility with Atm_fade
 
+Atm_led& Atm_led::lead( uint32_t ms ) {
+  lead_timer.set( ms );
+  return *this;
+} 
+
 Atm_led& Atm_led::repeat( uint16_t repeat ) {
   counter.set( repeat_count = repeat );
   return *this;
 }
 
-Atm_led& Atm_led::brightness( uint8_t level ) {
-  this->level = level;
-  if ( current == ON || current == START ) {
-    analogWrite( pin, level );
+int Atm_led::brightness( int level /* = -1 */ ) {
+  if ( level > -1 ) {
+    this->level = level;
+    if ( current == ON || current == START ) {
+      analogWrite( pin, mapLevel( level ) );
+    }
+  }
+  return this->level;
+}
+
+int Atm_led::brighten( int v ) {
+  if ( abs( v ) == 1 ) {
+    int br = (int)this->level + v;
+    if ( br > toHigh ) 
+      br = wrap ? toLow : toHigh;
+    if ( br < toLow ) 
+      br = wrap ? toHigh : toLow;
+    brightness( br );
+  }
+  return this->level;
+}
+
+Atm_led& Atm_led::trigger( int event ) {
+  if ( event > ELSE ) {
+    brighten( event == EVT_BRUP ? 1 : -1 );
+  } else {
+    Machine::trigger( event );
   }
   return *this;
 }
 
 Atm_led& Atm_led::trace( Stream& stream ) {
   setTrace( &stream, atm_serial_debug::trace,
-            "LED\0EVT_ON_TIMER\0EVT_OFF_TIMER\0EVT_COUNTER\0EVT_ON\0EVT_OFF\0EVT_"
+            "LED\0EVT_ON_TIMER\0EVT_OFF_TIMER\0EVT_WT_TIMER\0EVT_COUNTER\0EVT_ON\0EVT_OFF\0EVT_"
             "BLINK\0EVT_TOGGLE\0EVT_TOGGLE_BLINK\0ELSE\0"
-            "IDLE\0ON\0START\0BLINK_OFF\0LOOP\0DONE\0OFF" );
+            "IDLE\0ON\0START\0BLINK_OFF\0LOOP\0DONE\0OFF\0WT_ON\0WT_START" );
   return *this;
 }

--- a/src/Atm_led.cpp
+++ b/src/Atm_led.cpp
@@ -1,36 +1,41 @@
 #include "Atm_led.hpp"
 
-Atm_led& Atm_led::begin( int attached_pin, bool activeLow ) {
+Atm_led& Atm_led::begin( int attached_pin, bool activeLow, byte* blinkPattern, int blinkPatternSize ) {
   // clang-format off
   static const state_t state_table[] PROGMEM = {
-    /*               ON_ENTER    ON_LOOP    ON_EXIT  EVT_ON_TIMER  EVT_OFF_TIMER EVT_WT_TIMER EVT_COUNTER  EVT_ON  EVT_OFF  EVT_BLINK  EVT_TOGGLE  EVT_TOGGLE_BLINK   ELSE */
-    /* IDLE      */  ENT_INIT, ATM_SLEEP,        -1,           -1,            -1,          -1,         -1,  WT_ON,      -1,  WT_START,         ON,         WT_START,    -1, // LED off
-    /* ON        */    ENT_ON, ATM_SLEEP,        -1,           -1,            -1,          -1,         -1,     -1,     OFF,  WT_START,        OFF,              OFF,    -1, // LED on
-    /* START     */    ENT_ON,        -1,        -1,    BLINK_OFF,            -1,          -1,         -1,  WT_ON,     OFF,        -1,        OFF,              OFF,    -1, // Start blinking
-    /* BLINK_OFF */   ENT_OFF,        -1,        -1,           -1,          LOOP,          -1,         -1,  WT_ON,     OFF,        -1,        OFF,              OFF,    -1,
-    /* LOOP      */        -1,        -1,        -1,           -1,            -1,          -1,       DONE,  WT_ON,     OFF,        -1,        OFF,              OFF, START,    
-    /* DONE      */        -1,        -1, EXT_CHAIN,           -1,           OFF,          -1,         -1,  WT_ON,     OFF,  WT_START,        OFF,              OFF,    -1, // Wait after last blink
-    /* OFF       */   ENT_OFF,        -1,        -1,           -1,            -1,          -1,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,  IDLE, // All off -> IDLE
-    /* WT_ON     */        -1,        -1,        -1,           -1,            -1,          ON,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,    -1, // LEAD for ON
-    /* WT_START  */        -1,        -1,        -1,           -1,            -1,       START,         -1,  WT_ON,     OFF,  WT_START,         -1,               -1,    -1, // LEAD for BLINK
-  }; 
+    /*               ON_ENTER    ON_LOOP    ON_EXIT  EVT_ON_TIMER  EVT_OFF_TIMER  EVT_COUNTER  EVT_ON  EVT_OFF  EVT_BLINK  EVT_TOGGLE  EVT_TOGGLE_BLINK  ELSE */
+    /* IDLE      */  ENT_INIT, ATM_SLEEP,        -1,           -1,            -1,          -1,     ON,      -1,     START,         ON,            START,    -1, // LED off
+    /* ON        */    ENT_ON, ATM_SLEEP,        -1,           -1,            -1,          -1,     -1,     OFF,     START,        OFF,              OFF,    -1, // LED on
+    /* START     */    ENT_ON,        -1,        -1,    BLINK_OFF,            -1,          -1,     ON,     OFF,        -1,        OFF,              OFF,    -1, // Start blinking
+    /* BLINK_OFF */   ENT_OFF,        -1,        -1,           -1,          LOOP,          -1,     ON,     OFF,        -1,        OFF,              OFF,    -1,
+    /* LOOP      */        -1,        -1,        -1,           -1,            -1,        DONE,     ON,     OFF,        -1,        OFF,              OFF, START,    
+    /* DONE      */        -1,        -1, EXT_CHAIN,           -1,           OFF,          -1,     ON,     OFF,     START,        OFF,              OFF,    -1, // Wait after last blink
+    /* OFF       */   ENT_OFF,        -1,        -1,           -1,            -1,          -1,     ON,     OFF,     START,         -1,               -1,  IDLE, // All off -> IDLE
+  };
   // clang-format on
   Machine::begin( state_table, ELSE );
   pin = attached_pin;
   this->activeLow = activeLow;
   level = 255;
-  toLow = 0;
-  toHigh = 255;
-  wrap = false;
   pinMode( pin, OUTPUT );
   digitalWrite( pin, activeLow ? HIGH : LOW );
-  on_timer.set( 500 );
-  off_timer.set( 500 );
-  lead_timer.set( 0 );
-  repeat_count = ATM_COUNTER_OFF;
-  counter.set( repeat_count );
+  pattern = blinkPattern;
+  patternSize = blinkPatternSize;
+  reset();
   while ( state() != 0 ) cycle();
   return *this;
+}
+
+void Atm_led::reset() {
+  off_timer.set( offDuration );
+  if( pattern == NULL ) {
+    on_timer.set( onDuration );
+    repeat_count = ATM_COUNTER_OFF;
+  } else {
+    repeat_count = patternSize;
+    on_timer.set( onDuration * pattern[0] );
+  }
+  counter.set( repeat_count );
 }
 
 int Atm_led::event( int id ) {
@@ -39,8 +44,6 @@ int Atm_led::event( int id ) {
       return on_timer.expired( this );
     case EVT_OFF_TIMER:
       return off_timer.expired( this );
-    case EVT_WT_TIMER:
-      return lead_timer.expired( this );
     case EVT_COUNTER:
       return counter.expired();
   }
@@ -53,15 +56,13 @@ void Atm_led::action( int id ) {
       counter.set( repeat_count );
       return;
     case ENT_ON:
-      if ( on_timer.value > 0 ) { // Never turn if on_timer is zero (duty cycle 0 must be dark)
-        if ( activeLow ) {
-          digitalWrite( pin, LOW );
+      if ( activeLow ) {
+        digitalWrite( pin, LOW );
+      } else {
+        if ( level == 255 ) {
+          digitalWrite( pin, HIGH );
         } else {
-          if ( level == toHigh ) {
-            digitalWrite( pin, HIGH );
-          } else {
-            analogWrite( pin, mapLevel( level ) );
-          }
+          analogWrite( pin, level );
         }
       }
       return;
@@ -70,24 +71,26 @@ void Atm_led::action( int id ) {
       if ( !activeLow ) {
         digitalWrite( pin, LOW );
       } else {
-        if ( level == toHigh ) {
+        if ( level == 255 ) {
           digitalWrite( pin, HIGH );
         } else {
-          analogWrite( pin, mapLevel( level ) );
+          analogWrite( pin, level );
         }
+      }
+      if( state() == OFF ) {
+        // End of sequence, reset the counter in case it gets called again (eg, by an OnFinish connector)
+        counter.set( repeat_count );
+      }
+      if(pattern != NULL ) {
+        // Change the timer for the next On cycle.
+        int i = patternSize - counter.value;
+        on_timer.set(onDuration * pattern[i]);
       }
       return;
     case EXT_CHAIN:
+      reset();
       onfinish.push( 0 );
       return;
-  }
-}
-
-int Atm_led::mapLevel( int level ) {
-  if ( levelMapSize ) {
-    return levelMap[level];
-  } else {
-    return map( level, toLow, toHigh, 0, 255 );
   }
 }
 
@@ -129,37 +132,26 @@ Atm_led& Atm_led::onFinish( atm_cb_push_t callback, int idx /* = 0 */ ) {
 Atm_led& Atm_led::blink( uint32_t duration, uint32_t pause_duration, uint16_t repeat_count /* = ATM_COUNTER_OFF */ ) {
   blink( duration );  // Time in which led is fully on
   pause( pause_duration );
-  repeat( repeat_count );
+  if( patternSize == 0)
+    repeat( repeat_count );
   return *this;
 }
 
 Atm_led& Atm_led::blink( uint32_t duration ) {
+  onDuration = duration;
   on_timer.set( duration );  // Time in which led is fully on
   return *this;
 }
 
-Atm_led& Atm_led::blink( void ) {
-  trigger( EVT_BLINK );
-  return *this;
-}
-
-Atm_led& Atm_led::range( int toLow, int toHigh, bool wrap /* = false */ ) {
-  this->toLow = toLow; 
-  this->toHigh = toHigh; 
-  this->wrap = wrap;
-  level = toHigh;
-  return *this;
-}
-
-Atm_led& Atm_led::levels( unsigned char* map, int mapsize, bool wrap /* = false */ ) {
-  this->levelMap = map;
-  levelMapSize = mapsize;
-  range( 0, mapsize - 1, wrap );
-  return *this;
-}
-
 Atm_led& Atm_led::pause( uint32_t duration ) {  // Time in which led is fully off
+  offDuration = duration;
   off_timer.set( duration ? duration : 1 );     // Make sure off_timer is never 0 (work around)
+  return *this;
+}
+
+Atm_led& Atm_led::setpattern( byte* blinkPattern, uint32_t blinkPatternSize ) {
+  pattern = blinkPattern;
+  this->patternSize = blinkPatternSize;
   return *this;
 }
 
@@ -167,51 +159,23 @@ Atm_led& Atm_led::fade( int fade ) {
   return *this;
 }  // Dummy for method compatibility with Atm_fade
 
-Atm_led& Atm_led::lead( uint32_t ms ) {
-  lead_timer.set( ms );
-  return *this;
-} 
-
 Atm_led& Atm_led::repeat( uint16_t repeat ) {
   counter.set( repeat_count = repeat );
   return *this;
 }
 
-int Atm_led::brightness( int level /* = -1 */ ) {
-  if ( level > -1 ) {
-    this->level = level;
-    if ( current == ON || current == START ) {
-      analogWrite( pin, mapLevel( level ) );
-    }
-  }
-  return this->level;
-}
-
-int Atm_led::brighten( int v ) {
-  if ( abs( v ) == 1 ) {
-    int br = (int)this->level + v;
-    if ( br > toHigh ) 
-      br = wrap ? toLow : toHigh;
-    if ( br < toLow ) 
-      br = wrap ? toHigh : toLow;
-    brightness( br );
-  }
-  return this->level;
-}
-
-Atm_led& Atm_led::trigger( int event ) {
-  if ( event > ELSE ) {
-    brighten( event == EVT_BRUP ? 1 : -1 );
-  } else {
-    Machine::trigger( event );
+Atm_led& Atm_led::brightness( uint8_t level ) {
+  this->level = level;
+  if ( current == ON || current == START ) {
+    analogWrite( pin, level );
   }
   return *this;
 }
 
 Atm_led& Atm_led::trace( Stream& stream ) {
   setTrace( &stream, atm_serial_debug::trace,
-            "LED\0EVT_ON_TIMER\0EVT_OFF_TIMER\0EVT_WT_TIMER\0EVT_COUNTER\0EVT_ON\0EVT_OFF\0EVT_"
+            "LED\0EVT_ON_TIMER\0EVT_OFF_TIMER\0EVT_COUNTER\0EVT_ON\0EVT_OFF\0EVT_"
             "BLINK\0EVT_TOGGLE\0EVT_TOGGLE_BLINK\0ELSE\0"
-            "IDLE\0ON\0START\0BLINK_OFF\0LOOP\0DONE\0OFF\0WT_ON\0WT_START" );
+            "IDLE\0ON\0START\0BLINK_OFF\0LOOP\0DONE\0OFF" );
   return *this;
 }

--- a/src/Atm_led.hpp
+++ b/src/Atm_led.hpp
@@ -4,19 +4,21 @@
 
 class Atm_led : public Machine {
  public:
-  enum { IDLE, ON, START, BLINK_OFF, LOOP, DONE, OFF };
-  enum { EVT_ON_TIMER, EVT_OFF_TIMER, EVT_COUNTER, EVT_ON, EVT_OFF, EVT_BLINK, EVT_TOGGLE, EVT_TOGGLE_BLINK, ELSE };
+  enum { IDLE, ON, START, BLINK_OFF, LOOP, DONE, OFF, WT_ON, WT_START };
+  enum { EVT_ON_TIMER, EVT_OFF_TIMER, EVT_WT_TIMER, EVT_COUNTER, EVT_ON, EVT_OFF, EVT_BLINK, EVT_TOGGLE, EVT_TOGGLE_BLINK, ELSE, EVT_BRUP, EVT_BRDN }; // BRUP/BRDN pseudo
   enum { EVT_START = EVT_BLINK };
 
   Atm_led( void ) : Machine(){};
   Atm_led& begin( int attached_pin, bool activeLow = false, byte* blinkPattern = NULL, int blinkPatternSize = 0);
+  Atm_led& blink( void );
   Atm_led& blink( uint32_t duration );
   Atm_led& blink( uint32_t duration, uint32_t pause_duration, uint16_t repeat_count = ATM_COUNTER_OFF );
   Atm_led& pause( uint32_t duration );
   Atm_led& setpattern( byte* pattern, uint32_t patternSize );
   Atm_led& fade( int fade );
+  Atm_led& lead( uint32_t ms );
   Atm_led& repeat( uint16_t repeat );
-  Atm_led& brightness( uint8_t level );
+  int brightness( int level = -1 );
   Atm_led& on( void );
   Atm_led& off( void );
   Atm_led& toggle( void );
@@ -25,17 +27,28 @@ class Atm_led : public Machine {
   Atm_led& trace( Stream& stream );
   Atm_led& onFinish( Machine& machine, int event = 0 );
   Atm_led& onFinish( atm_cb_push_t callback, int idx = 0 );
+  Atm_led& range( int toLow, int toHigh, bool wrap = false );
+  Atm_led& levels( unsigned char* map, int mapsize, bool wrap = false );
+  int brighten( int v = 1 );
+  Atm_led& trigger( int event );
 
  private:
   enum { ENT_INIT, ENT_ON, ENT_OFF, EXT_CHAIN };
   uint8_t level;
   short pin;
   bool activeLow;
+  uint8_t toHigh, toLow;
+  bool wrap;
   uint16_t repeat_count;
-  atm_timer_millis on_timer, off_timer;
+  atm_timer_millis on_timer, off_timer, lead_timer;
   atm_counter counter;
   atm_connector onfinish;
   byte* pattern;
+
+  unsigned char* levelMap;
+  int levelMapSize;  
+  int mapLevel( int level );
+
   uint32_t patternSize; 
   uint32_t onDuration = 500;
   uint32_t offDuration = 500;

--- a/src/Atm_led.hpp
+++ b/src/Atm_led.hpp
@@ -4,20 +4,19 @@
 
 class Atm_led : public Machine {
  public:
-  enum { IDLE, ON, START, BLINK_OFF, LOOP, DONE, OFF, WT_ON, WT_START };
-  enum { EVT_ON_TIMER, EVT_OFF_TIMER, EVT_WT_TIMER, EVT_COUNTER, EVT_ON, EVT_OFF, EVT_BLINK, EVT_TOGGLE, EVT_TOGGLE_BLINK, ELSE, EVT_BRUP, EVT_BRDN }; // BRUP/BRDN pseudo
+  enum { IDLE, ON, START, BLINK_OFF, LOOP, DONE, OFF };
+  enum { EVT_ON_TIMER, EVT_OFF_TIMER, EVT_COUNTER, EVT_ON, EVT_OFF, EVT_BLINK, EVT_TOGGLE, EVT_TOGGLE_BLINK, ELSE };
   enum { EVT_START = EVT_BLINK };
 
   Atm_led( void ) : Machine(){};
-  Atm_led& begin( int attached_pin, bool activeLow = false );
-  Atm_led& blink( void );
+  Atm_led& begin( int attached_pin, bool activeLow = false, byte* blinkPattern = NULL, int blinkPatternSize = 0);
   Atm_led& blink( uint32_t duration );
   Atm_led& blink( uint32_t duration, uint32_t pause_duration, uint16_t repeat_count = ATM_COUNTER_OFF );
   Atm_led& pause( uint32_t duration );
+  Atm_led& setpattern( byte* pattern, uint32_t patternSize );
   Atm_led& fade( int fade );
-  Atm_led& lead( uint32_t ms );
   Atm_led& repeat( uint16_t repeat );
-  int brightness( int level = -1 );
+  Atm_led& brightness( uint8_t level );
   Atm_led& on( void );
   Atm_led& off( void );
   Atm_led& toggle( void );
@@ -26,27 +25,22 @@ class Atm_led : public Machine {
   Atm_led& trace( Stream& stream );
   Atm_led& onFinish( Machine& machine, int event = 0 );
   Atm_led& onFinish( atm_cb_push_t callback, int idx = 0 );
-  Atm_led& range( int toLow, int toHigh, bool wrap = false );
-  Atm_led& levels( unsigned char* map, int mapsize, bool wrap = false );
-  int brighten( int v = 1 );
-  Atm_led& trigger( int event );
 
  private:
   enum { ENT_INIT, ENT_ON, ENT_OFF, EXT_CHAIN };
   uint8_t level;
   short pin;
   bool activeLow;
-  uint8_t toHigh, toLow;
-  bool wrap;
   uint16_t repeat_count;
-  atm_timer_millis on_timer, off_timer, lead_timer;
+  atm_timer_millis on_timer, off_timer;
   atm_counter counter;
   atm_connector onfinish;
-  unsigned char* levelMap;
-  int levelMapSize;  
-  int mapLevel( int level );
+  byte* pattern;
+  uint32_t patternSize; 
+  uint32_t onDuration = 500;
+  uint32_t offDuration = 500;
 
-
+  void reset();
   int event( int id );
   void action( int id );
 };


### PR DESCRIPTION
Allows an LED object to blink in a pattern specified in a byte array.  Each element in the array is a multiplier for the on time.  I wanted this so I can chain up blinked error codes.

Also, resetting the counter when state() == OFF seems useful for any kind of repeat, not just patterns.