### PR TITLE
 Added virtual functions to allow easy adaption to other button-types  … (e.g touch or IO extender)

### DIFF
--- a/examples/extern_LED/.vscode/settings.json
+++ b/examples/extern_LED/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "terminal.integrated.env.linux": {
+        "PATH": "/home/ian/.platformio/penv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+    }
+}

--- a/examples/extern_LED/Atm_led_mcp.cpp
+++ b/examples/extern_LED/Atm_led_mcp.cpp
@@ -1,0 +1,36 @@
+/*
+ * Atm_led_mcp.cpp
+ *
+ *  Created on: 09.12.2017
+ *      Author: ian
+ */
+
+#include <Atm_led_mcp.h>
+#include <Atm_led.hpp>
+
+Atm_led_mcp::Atm_led_mcp(Adafruit_MCP23017& _gpio):
+	Atm_led(),			// base class ctor would also be called implicitly, but better style to mention this explicitly :)
+	gpio(_gpio) {
+	// nothing to see here
+}
+
+void Atm_led_mcp::initLED() {
+	gpio.pinMode(pin, OUTPUT);
+	gpio.digitalWrite(pin, activeLow ? HIGH : LOW);
+	Serial.printf("LED init on pin %c%x\n", activeLow?'~':' ', pin);
+}
+
+void Atm_led_mcp::switchOn() {
+	Serial.printf("LED ON on pin %c%x\n", activeLow?'~':' ', pin);
+	gpio.digitalWrite(pin, !activeLow);
+}
+
+void Atm_led_mcp::switchOff() {
+	Serial.printf("LED OFF on pin %c%x\n", activeLow?'~':' ', pin);
+	gpio.digitalWrite(pin, activeLow);
+}
+
+void Atm_led_mcp::setBrightness(int value) {
+	if (value == toHigh) switchOn(); else if(value==toLow) switchOff(); else
+	Serial.printf("ERROR: Setting brightness on GPIO expander is not possible (pin: %d)\n", pin);
+}

--- a/examples/extern_LED/Atm_led_mcp.h
+++ b/examples/extern_LED/Atm_led_mcp.h
@@ -1,0 +1,28 @@
+/*
+ * Atm_led_mcp.h
+ *
+ *  Created on: 09.12.2017
+ *      Author: ian
+ */
+
+#ifndef SRC_ATM_LED_MCP_H_
+#define SRC_ATM_LED_MCP_H_
+
+#include "Adafruit_MCP23017.h"
+#include <Atm_led.hpp>
+
+class Atm_led_mcp: public Atm_led {
+public:
+	Atm_led_mcp(Adafruit_MCP23017& _gpio);
+
+private:
+	Adafruit_MCP23017& gpio;
+
+protected:
+	virtual void initLED();
+	virtual void switchOn();
+	virtual void switchOff();
+    virtual void setBrightness(int value);
+};
+
+#endif /* SRC_ATM_LED_MCP_H_ */

--- a/examples/extern_LED/main.cpp
+++ b/examples/extern_LED/main.cpp
@@ -1,0 +1,18 @@
+#include <automaton.h>
+#include <atm_led_mcp.h>
+#include "Adafruit_MCP23017.h"
+
+
+Adafruit_MCP23017 ioext;
+Atm_led_mcp led(ioext);
+
+
+void setup() {
+  ioext.begin();
+  led.begin(6, true);
+  led.On();
+}
+
+void loop() {
+  automaton.run();
+}

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,0 +1,54 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+
+#env_default = esp12e
+env_default = d1_mini
+
+[common_env_data]
+
+# Automaton + PR #50 (https://github.com/tinkerspy/Automaton/pull/50)
+# Automaton-Esp8266 + PR #5 (https://github.com/tinkerspy/Automaton-Esp8266/pull/5)
+# 334 = Adafruit MCP23017 Arduino Library
+lib_deps_ext =	https://github.com/euphi/Automaton.git
+		https://github.com/euphi/Automaton-Esp8266.git
+		MFRC522
+		Adafruit MCP23017 Arduino Library
+
+lib_deps_int = Hash
+
+[env:esp12e]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+
+lib_ldf_mode=chain+
+lib_deps= ${common_env_data.lib_deps_int}
+	  ${common_env_data.lib_deps_ext}
+
+# Build for ESP-ADC (in-circuit), 512kb Flash only!
+build_flags = -Wl,-Tesp8266.flash.512k64.ld                                                                                                                                                                                                                                    
+
+# ck: DTR connected to GPIO0, RTS connected to RESET
+upload_resetmethod = ck
+upload_speed = 460800
+
+
+[env:d1_mini]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+
+lib_ldf_mode=chain+
+lib_deps= ${common_env_data.lib_deps_int}
+	  ${common_env_data.lib_deps_ext}
+
+upload_speed = 460800

--- a/src/Atm_button.cpp
+++ b/src/Atm_button.cpp
@@ -21,14 +21,14 @@ Atm_button& Atm_button::begin( int attached_pin ) {
     /* AUTO_ST   */      ENT_AUTO,      -1,           -1,        -1,        -1,        -1,         -1,       -1,          -1,          -1,        -1,  IDLE,
   };
   // clang-format on
-  Machine::begin( state_table, ELSE );
   pin = attached_pin;
+  Machine::begin( state_table, ELSE );
   counter_longpress.set( 0 );
   timer_debounce.set( DEBOUNCE );
   timer_delay.set( ATM_TIMER_OFF );
   timer_repeat.set( ATM_TIMER_OFF );
   timer_auto.set( ATM_TIMER_OFF );
-  pinMode( pin, INPUT_PULLUP );
+  initButton();
   return *this;
 }
 
@@ -45,9 +45,9 @@ int Atm_button::event( int id ) {
     case EVT_AUTO:
       return timer_auto.expired( this );
     case EVT_PRESS:
-      return !digitalRead( pin );
+    	return isPressed();
     case EVT_RELEASE:
-      return digitalRead( pin );
+    	return isReleased();
     case EVT_COUNTER:
       return counter_longpress.expired();
   }
@@ -150,4 +150,16 @@ Atm_button& Atm_button::trace( Stream& stream ) {
             "BUTTON\0EVT_LMODE\0EVT_TIMER\0EVT_DELAY\0EVT_REPEAT\0EVT_PRESS\0EVT_RELEASE\0EVT_COUNTER\0EVT_"
             "AUTO_ST\0ELSE\0IDLE\0WAIT\0PRESSED\0REPEAT\0RELEASE\0LIDLE\0LWAIT\0LPRESSED\0LRELEASE\0WRELEASE\0AUTO" );
   return *this;
+}
+
+void Atm_button::initButton() {
+	pinMode( pin, INPUT_PULLUP );
+}
+
+bool Atm_button::isPressed() {
+	return !digitalRead( pin );
+}
+
+bool Atm_button::isReleased() {
+	return digitalRead( pin );
 }

--- a/src/Atm_button.cpp
+++ b/src/Atm_button.cpp
@@ -21,8 +21,8 @@ Atm_button& Atm_button::begin( int attached_pin ) {
     /* AUTO_ST   */      ENT_AUTO,      -1,           -1,        -1,        -1,        -1,         -1,       -1,          -1,          -1,        -1,  IDLE,
   };
   // clang-format on
-  pin = attached_pin;
   Machine::begin( state_table, ELSE );
+  pin = attached_pin;
   counter_longpress.set( 0 );
   timer_debounce.set( DEBOUNCE );
   timer_delay.set( ATM_TIMER_OFF );

--- a/src/Atm_button.hpp
+++ b/src/Atm_button.hpp
@@ -35,4 +35,8 @@ class Atm_button : public Machine {
 
   int event( int id );
   void action( int id );
+
+  virtual void initButton();
+  virtual bool isPressed();
+  virtual bool isReleased();
 };

--- a/src/Atm_led.cpp
+++ b/src/Atm_led.cpp
@@ -22,8 +22,7 @@ Atm_led& Atm_led::begin( int attached_pin, bool activeLow ) {
   toLow = 0;
   toHigh = 255;
   wrap = false;
-  pinMode( pin, OUTPUT );
-  digitalWrite( pin, activeLow ? HIGH : LOW );
+  initLED();
   on_timer.set( 500 );
   off_timer.set( 500 );
   lead_timer.set( 0 );
@@ -53,29 +52,11 @@ void Atm_led::action( int id ) {
       counter.set( repeat_count );
       return;
     case ENT_ON:
-      if ( on_timer.value > 0 ) { // Never turn if on_timer is zero (duty cycle 0 must be dark)
-        if ( activeLow ) {
-          digitalWrite( pin, LOW );
-        } else {
-          if ( level == toHigh ) {
-            digitalWrite( pin, HIGH );
-          } else {
-            analogWrite( pin, mapLevel( level ) );
-          }
-        }
-      }
+   	  switchOn();
       return;
     case ENT_OFF:
       counter.decrement();
-      if ( !activeLow ) {
-        digitalWrite( pin, LOW );
-      } else {
-        if ( level == toHigh ) {
-          digitalWrite( pin, HIGH );
-        } else {
-          analogWrite( pin, mapLevel( level ) );
-        }
-      }
+      switchOff();
       return;
     case EXT_CHAIN:
       onfinish.push( 0 );
@@ -181,7 +162,7 @@ int Atm_led::brightness( int level /* = -1 */ ) {
   if ( level > -1 ) {
     this->level = level;
     if ( current == ON || current == START ) {
-      analogWrite( pin, mapLevel( level ) );
+      setBrightness(mapLevel(level));
     }
   }
   return this->level;
@@ -214,4 +195,39 @@ Atm_led& Atm_led::trace( Stream& stream ) {
             "BLINK\0EVT_TOGGLE\0EVT_TOGGLE_BLINK\0ELSE\0"
             "IDLE\0ON\0START\0BLINK_OFF\0LOOP\0DONE\0OFF\0WT_ON\0WT_START" );
   return *this;
+}
+
+void Atm_led::initLED() {
+	pinMode(pin, OUTPUT);
+	digitalWrite(pin, activeLow ? HIGH : LOW);
+}
+
+void Atm_led::switchOn() {
+	// Never turn if on_timer is zero (duty cycle 0 must be dark)
+	if (on_timer.value == 0) return;
+	if (activeLow) {
+		digitalWrite(pin, LOW);
+	} else {
+		if (level == toHigh) {
+			digitalWrite(pin, HIGH);
+		} else {
+			analogWrite(pin, mapLevel(level));
+		}
+	}
+}
+
+void Atm_led::switchOff() {
+	if (!activeLow) {
+		digitalWrite(pin, LOW);
+	} else {
+		if (level == toHigh) {
+			digitalWrite(pin, HIGH);
+		} else {
+			analogWrite(pin, mapLevel(level));
+		}
+	}
+}
+
+void Atm_led::setBrightness(int value) {
+	analogWrite( pin, value );
 }

--- a/src/Atm_led.hpp
+++ b/src/Atm_led.hpp
@@ -34,19 +34,24 @@ class Atm_led : public Machine {
  private:
   enum { ENT_INIT, ENT_ON, ENT_OFF, EXT_CHAIN };
   uint8_t level;
-  short pin;
-  bool activeLow;
-  uint8_t toHigh, toLow;
-  bool wrap;
   uint16_t repeat_count;
   atm_timer_millis on_timer, off_timer, lead_timer;
   atm_counter counter;
   atm_connector onfinish;
   unsigned char* levelMap;
   int levelMapSize;  
-  int mapLevel( int level );
 
 
   int event( int id );
   void action( int id );
+ protected:
+  short pin;
+  bool activeLow;
+  uint8_t toHigh, toLow;
+  bool wrap;
+  virtual void initLED();
+  virtual void switchOn();
+  virtual void switchOff();
+  virtual void setBrightness(int value);
+  virtual int mapLevel( int level );
 };


### PR DESCRIPTION
To be able to use `Atm_button` for buttons that are not directly connected to a GPIO  I created virtual methods

```C++
	  virtual void initButton();
	  virtual bool isPressed();
	  virtual bool isReleased();
```
`initButton()` is called from `begin()` to initialize the button (e.g. set INPUT_PULLUP) the other methods are called from `event()` to check if they trigger the related event.

The default implementation still has the same behaviour as before, but this allows to derive an own class and overwrite these methods, so you can read other PINs, e.g a touch controller (like MPR121) or IO expander (PCF8575).

See https://github.com/euphi/ESP-Touch/blob/Display_WS2812/src/AtmTouchButton.cpp & https://github.com/euphi/ESP-Touch/blob/Display_WS2812/src/AtmTouchButton.h
for example usage with MPR121 I2C touch controller.