### PR TITLE
added atm_timer_millis.setFromNow( Machine* machine, uint32_t v )

### DIFF
--- a/src/atm_timer_millis.cpp
+++ b/src/atm_timer_millis.cpp
@@ -11,6 +11,14 @@ void atm_timer_millis::set( uint32_t v ) {
 }
 
 /*
+ * atm_timer_millis::setFromNow( Machine* machine, uint32_t v ) -
+ * Sets the timer to be expired v millis from now
+ */
+void atm_timer_millis::setFromNow( Machine* machine, uint32_t v ) {
+  value = millis() - machine->state_millis + v;
+}
+
+/*
  * atm_timer_millis::expired( this ) - Checks a millis timer for expiry (== 0)
  * This is a rollover-safe 32 bit unsigned integer comparison
  *

--- a/src/atm_timer_millis.hpp
+++ b/src/atm_timer_millis.hpp
@@ -11,5 +11,6 @@ class atm_timer_millis {
  public:
   uint32_t value;
   void set( uint32_t v );
+  void setFromNow( Machine* machine, uint32_t v );
   int expired( Machine* machine );
 };


### PR DESCRIPTION
Offers the ability to set alarm expiration using relative time at the moment of the method call.  It can be used to set a new or adjust the expiration based on some condition without having to introduce a new state for the Automaton.