### PR TITLE
'Test for lambda' - allow calllback to real lambda functions

### DIFF
--- a/src/Machine.cpp
+++ b/src/Machine.cpp
@@ -146,6 +146,25 @@ void Machine::onPush( atm_connector connectors[], int id, int sub, int slots, in
   }
 }
 
+void Machine::onPush( atm_connector connectors[], int id, int sub, int slots, int fill, atm_cb_lambda_t lambdacallback, int idx ) {
+  if ( sub == -1 ) {  // auto store
+    sub = 0;
+    for ( int i = 0; i < slots; i++ ) {
+      if ( connectors[id + i].mode() == 0 ) {  // Find a free slot
+        sub = i;
+      }
+    }
+  }
+  if ( slots > 1 && fill ) {
+    for ( int i = 0; i < slots; i++ ) {
+      connectors[id + i].set( lambdacallback, idx );
+    }
+  } else {
+    connectors[id + sub].set( lambdacallback, idx );
+  }
+}
+
+
 /*
  * Machine::push( connectors, id, sub, v, up ) - Pushes an action through the specified connector
  *

--- a/src/Machine.hpp
+++ b/src/Machine.hpp
@@ -25,6 +25,8 @@ class Machine {
   Machine& setTrace( Stream* stream, swcb_sym_t callback, const char symbols[] );
   void onPush( atm_connector connectors[], int id, int sub, int slots, int fill, Machine& machine, int event );
   void onPush( atm_connector connectors[], int id, int sub, int slots, int fill, atm_cb_push_t callback, int idx );
+  void onPush( atm_connector connectors[], int id, int sub, int slots, int fill, atm_cb_lambda_t lambdacallback, int idx );
+
   void push( atm_connector connectors[], int id, int sub, int v, int up );
 
   const state_t* state_table;

--- a/src/atm_connector.cpp
+++ b/src/atm_connector.cpp
@@ -32,6 +32,10 @@ bool atm_connector::push( int v /* = 0 */, int up /* = 0 */, bool overrideCallba
         machine->trigger( event );
       }
       return true;
+
+    case MODE_LAMBDA:
+           (*lambda_callback)( callback_idx, v, up );
+           return true;
   }
   return true;
 }
@@ -102,6 +106,12 @@ void atm_connector::set( Machine* m, int evt, int8_t logOp /* = 0 */, int8_t rel
   event = evt;
 }
 
+void atm_connector::set(atm_cb_lambda_t callback, int idx, int8_t logOp, int8_t relOp) {
+	  mode_flags = MODE_LAMBDA | ( logOp << 3 ) | ( relOp << 5 );
+	  lambda_callback = callback;
+	  callback_idx = idx;
+}
+
 /*
  * mode() - Returns the mode part of the mode_flags byte
  *
@@ -110,3 +120,4 @@ void atm_connector::set( Machine* m, int evt, int8_t logOp /* = 0 */, int8_t rel
 int8_t atm_connector::mode( void ) {
   return mode_flags & B00000111;
 }
+

--- a/src/atm_connector.cpp
+++ b/src/atm_connector.cpp
@@ -34,7 +34,7 @@ bool atm_connector::push( int v /* = 0 */, int up /* = 0 */, bool overrideCallba
       return true;
 
     case MODE_LAMBDA:
-           (*lambda_callback)( callback_idx, v, up );
+           (lambda_callback)( callback_idx, v, up );
            return true;
   }
   return true;

--- a/src/atm_connector.hpp
+++ b/src/atm_connector.hpp
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "Arduino.h"
+#include <functional>
 
+typedef std::function<void (int idx, int v, int up)> atm_cb_lambda_t;
 typedef void ( *atm_cb_push_t )( int idx, int v, int up );
 typedef bool ( *atm_cb_pull_t )( int idx );
 
 class atm_connector {
  public:
-  enum { MODE_NULL, MODE_PUSHCB, MODE_PULLCB, MODE_MACHINE };            // bits 0, 1, 2 - Mode
+  enum { MODE_NULL, MODE_PUSHCB, MODE_PULLCB, MODE_MACHINE, MODE_LAMBDA };            // bits 0, 1, 2 - Mode
   enum { LOG_AND, LOG_OR, LOG_XOR };                                     // bits 3, 4    - Logical operator
   enum { REL_NULL, REL_EQ, REL_NEQ, REL_LT, REL_GT, REL_LTE, REL_GTE };  // bits 5, 6, 7 - Relational operator
   uint8_t mode_flags;
@@ -16,6 +18,8 @@ class atm_connector {
       union {
         atm_cb_push_t push_callback;
         atm_cb_pull_t pull_callback;
+        atm_cb_lambda_t lambda_callback; // FIXME: UNTESTED: Pointer to lambda function for callback
+
       };
       int callback_idx;  // +2 = 5 bytes per connector/object
     };
@@ -29,6 +33,7 @@ class atm_connector {
   void set( Machine* m, int evt, int8_t logOp = 0, int8_t relOp = 0 );
   void set( atm_cb_push_t callback, int idx, int8_t logOp = 0, int8_t relOp = 0 );
   void set( atm_cb_pull_t callback, int idx, int8_t logOp = 0, int8_t relOp = 0 );
+  void set( atm_cb_lambda_t callback, int idx, int8_t logOp = 0, int8_t relOp = 0 ); // ### Test
   bool push( int v = 0, int up = 0, bool overrideCallback = false );  // returns false (only) if callback is set!
   int pull( int v = 0, int up = 0, bool def_value = false );
   int8_t logOp( void );

--- a/src/atm_connector.hpp
+++ b/src/atm_connector.hpp
@@ -18,8 +18,6 @@ class atm_connector {
       union {
         atm_cb_push_t push_callback;
         atm_cb_pull_t pull_callback;
-        atm_cb_lambda_t lambda_callback; // FIXME: UNTESTED: Pointer to lambda function for callback
-
       };
       int callback_idx;  // +2 = 5 bytes per connector/object
     };
@@ -30,6 +28,8 @@ class atm_connector {
       int event;
     };
   };
+  atm_cb_lambda_t lambda_callback; // FIXME: UNTESTED: Pointer to lambda function for callback
+
   void set( Machine* m, int evt, int8_t logOp = 0, int8_t relOp = 0 );
   void set( atm_cb_push_t callback, int idx, int8_t logOp = 0, int8_t relOp = 0 );
   void set( atm_cb_pull_t callback, int idx, int8_t logOp = 0, int8_t relOp = 0 );


### PR DESCRIPTION
** Please note: This PR works for me but has not yet been tested extensively. For now, it is just a proposal for discussion **

The connector mechanism ("onPush") does not allow to use a lamba-function that capture [this]. So you can't callback a method. (it works for lambdas that don't catch anything).

To solve this, I added a `typedef std::function<void (int idx, int v, int up)> atm_cb_lambda_t;` and extended the logic in `Machine` and `atm_connector` to support callback to this type.

**Unfortunately this cannot be stored in the union together with the C-style function pointers, so it takes some additional space. (Maybe someone with more C++ experience can help here?)**

You can find a usage example in https://github.com/euphi/ESP_HomieRollerShutter , especially
https://github.com/euphi/ESP_HomieRollerShutter/blob/master/src/HomieRollershutter.cpp , line 30/31.

There are multiple instances of the HomieRollershutter class, so capturing [this] is necessary for correct logic.


