### PR TITLE
fixed compabilty with certain (older) Arduino Core verison

### DIFF
--- a/src/Automaton.h
+++ b/src/Automaton.h
@@ -7,6 +7,17 @@
 
 #include "Arduino.h"
 
+/*
+  fixing bug cause by new ardiuino api version
+  See https://github.com/arduino/ArduinoCore-API/issues/25
+*/
+#if (ARDUINO_API_VERSION >= 10000)
+  
+  inline void digitalWrite(unsigned pin, bool status) { 
+    digitalWrite(pin, status ? 1 : 0); 
+  };
+#endif
+
 typedef int8_t state_t;
 
 const uint8_t ATM_SLEEP_FLAG = 0b00000001;


### PR DESCRIPTION
See https://github.com/arduino/ArduinoCore-API/issues/25

had some problems using this library with platform.io on the Arduino Nano Every using megaavr core v1.8.5 and implicit casts off bool to PinStatus. The should have been fixed in v1.8.6.

Not sure if merging this makes much sense, so feel free to just close this request.